### PR TITLE
Docker updates

### DIFF
--- a/.github/workflows/quicktest-dev-pr.yml
+++ b/.github/workflows/quicktest-dev-pr.yml
@@ -20,4 +20,4 @@ jobs:
       - name: DockerRunQuicktest
         run: |
           docker build -f docker/Dockerfile -t finn-base-gha .
-          docker run --rm -v $(pwd):/workspace/finn-base finn-base-gha
+          docker run --rm -v $(pwd):/workspace/finn-base finn-base-gha quicktest.sh

--- a/.github/workflows/quicktest-dev-pr.yml
+++ b/.github/workflows/quicktest-dev-pr.yml
@@ -19,5 +19,5 @@ jobs:
 
       - name: DockerRunQuicktest
         run: |
-          docker build -f docker/Dockerfile -t finn-base-gha .
+          docker build -f docker/Dockerfile.ci -t finn-base-gha .
           docker run --rm -v $(pwd):/workspace/finn-base finn-base-gha quicktest.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,8 +36,8 @@ ARG UID
 RUN pip install --upgrade pip
 
 # Add host user
-RUN groupadd -g $GID $GNAME -f
-RUN useradd -u $UID $UNAME -g $GNAME -ms /bin/bash
+RUN groupadd -f -g $GID $GNAME
+RUN useradd -u $UID -g $GNAME -ms /bin/bash $UNAME
 RUN usermod -aG sudo $UNAME
 USER $UNAME
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,7 +36,7 @@ ARG UID
 RUN pip install --upgrade pip
 
 # Add host user
-RUN groupadd -f -g $GID $GNAME
+RUN groupadd -g $GID -f $GNAME
 RUN useradd -u $UID -g $GNAME -ms /bin/bash $UNAME
 RUN usermod -aG sudo $UNAME
 USER $UNAME

--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -28,33 +28,13 @@
 
 FROM mcr.microsoft.com/azureml/onnxruntime:latest
 MAINTAINER Yaman Umuroglu <yamanu@xilinx.com>
-ARG GID
-ARG GNAME
-ARG UNAME
-ARG UID
 
 RUN pip install --upgrade pip
 
-# Add host user
-RUN groupadd -g $GID $GNAME -f
-RUN useradd -u $UID -g $GNAME -ms /bin/bash $UNAME
-RUN usermod -aG sudo $UNAME
-USER $UNAME
-
-# Set ENV
-ENV PYTHONPATH "${PYTHONPATH}:/workspace/finn-base/src"
-ENV PATH "${PATH}:/home/$UNAME/.local/bin"
-
-# Color prompt
-RUN echo "PS1='\[\033[1;36m\]\u\[\033[1;31m\]@\[\033[1;32m\]\h:\[\033[1;35m\]\w\[\033[1;31m\]\$\[\033[0m\] '" >> /home/$UNAME/.bashrc
-
-# Copy entrypoint script as root then switch back to user
-USER root
 COPY ./docker/entrypoint.sh /usr/local/bin/
 COPY ./docker/quicktest.sh /usr/local/bin/
 RUN chmod 755 /usr/local/bin/entrypoint.sh
 RUN chmod 755 /usr/local/bin/quicktest.sh
-USER $UNAME
 
 ENTRYPOINT ["entrypoint.sh"]
 CMD ["bash"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -27,5 +27,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-cd /workspace/finn-base
-python setup.py develop && python setup.py test $@
+export SHELL=/bin/bash
+
+pip install --user -e /workspace/finn-base
+exec $@

--- a/docker/quicktest.sh
+++ b/docker/quicktest.sh
@@ -27,12 +27,5 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-SCRIPT=$(readlink -f "$0")
-FINN_BASE_ROOT=$(dirname "$SCRIPT")
-DOCKER_TAG=finn-base
-
-# Build the finn-base Docker image
-docker build -f docker/Dockerfile -t $DOCKER_TAG .
-
-# Mount source folder and run test suite
-docker run --rm -it -v $FINN_BASE_ROOT:/workspace/finn-base $DOCKER_TAG $@
+cd /workspace/finn-base
+python setup.py test

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -58,7 +58,7 @@ docker build -f docker/Dockerfile -t $DOCKER_TAG \
             .
 
 # Launch container with current directory mounted
-docker run -t --rm $DOCKER_INTERACTIVE --name $DOCKER_TAG \
+docker run -t --rm $DOCKER_INTERACTIVE \
            -v $SCRIPTPATH:/workspace/finn-base \
            -w /workspace \
            -e SHELL=/bin/bash \


### PR DESCRIPTION
> [<img alt="sjain-stanford" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/sjain-stanford) **Authored by [sjain-stanford](https://github.com/sjain-stanford)**
_<time datetime="2020-09-24T08:23:11Z" title="Thursday, September 24th 2020, 8:23:11 am +00:00">Sep 24, 2020</time>_
_Merged <time datetime="2020-09-24T14:04:55Z" title="Thursday, September 24th 2020, 2:04:55 pm +00:00">Sep 24, 2020</time>_
---

#### Updates:
1. Allows building docker image even from NFS mounts without permissions issue (resulting from root-squashing protection); now switches to host user before running.
2. Supports both interactive (./run-docker.sh) and quicktest (./run-docker.sh test) modes.

#### Note:
If the clone of finn-base has stale files (e.g. `./.eggs/*`) from earlier `run-docker-test.sh` it must have created some of those files as root. If so, running the new `run-docker.sh` fails as it tried to modify root owned files.

So if you want to give this a spin, I recommend doing the following (one-time):
  - [ ] Make sure you don't have locally modified files, or have them backed up. Then:
  - [ ] `sudo rm -rf finn-base`
  - [ ] Clone fresh
  - [ ] `run-docker.sh` should work now both on local disk as well as NFS mounts.